### PR TITLE
Remove misguided sfadmin organization edit route

### DIFF
--- a/app/controllers/sfadmin/organizations_controller.rb
+++ b/app/controllers/sfadmin/organizations_controller.rb
@@ -16,9 +16,6 @@ module Sfadmin
     def show
     end
 
-    def edit
-    end
-
     def update
       if(@organization.update(organization_params))
         flash[:notice] = "Organization saved successfully"

--- a/app/views/sfadmin/organizations/edit.html.haml
+++ b/app/views/sfadmin/organizations/edit.html.haml
@@ -1,5 +1,0 @@
-- content_for :title, "Edit #{@organization.name}"
-
-= simple_form_for(@organization, url: sfadmin_organization_path(@organization)) do |f|
-  = f.input :name
-  = f.button :submit

--- a/app/views/sfadmin/organizations/show.html.haml
+++ b/app/views/sfadmin/organizations/show.html.haml
@@ -2,9 +2,6 @@
 .container
   .row
     .col-sm-12
-      %h1.page-header
-        = yield :title
-        = link_to '(edit)', edit_sfadmin_organization_path(@organization.slug)
       = aasm_validation_errors_for(@organization)
       = render @organization
       %h2.sub-header= Location.model_name.human.pluralize

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,7 @@ Rails.application.routes.draw do
   end
 
   namespace :sfadmin do
-    resources :organizations do
+    resources :organizations, only: [:index, :show, :update] do
       resources :locations do
         resources :addresses
         resources :contacts

--- a/spec/features/sfadmin/organization/update_name_spec.rb
+++ b/spec/features/sfadmin/organization/update_name_spec.rb
@@ -1,26 +1,29 @@
 require "rails_helper"
 
 feature "Update name" do
-  scenario "with empty organization name" do
+  pending "with empty organization name" do
     organization = create(:organization)
     login_super_admin
-    visit "/sfadmin/organizations/#{organization.slug}/edit"
 
+    visit "/sfadmin/organizations/#{organization.slug}"
+    click_on("edit name")
     fill_in "organization_name", with: ""
-    click_button "Update Organization"
+    click_button "Save"
 
     expect(page).to have_content "can't be blank"
   end
 
-  scenario "with valid organization name" do
+  pending "with valid organization name" do
     organization = create(:organization)
     login_super_admin
-    visit "/sfadmin/organizations/#{organization.slug}/edit"
+    new_name = "Juvenile Sexual Responsibility Program"
 
-    fill_in "organization_name", with: "Juvenile Sexual Responsibility Program"
-    click_button "Update Organization"
+    visit "/sfadmin/organizations/#{organization.slug}"
+    click_on("edit name")
+    fill_in "organization_name", with: new_name
+    click_button "Save"
 
     expect(page).to have_content("saved successfully")
-    expect(page).to have_content("Juvenile Sexual Responsibility Program")
+    expect(page).to have_content(new_name)
   end
 end


### PR DESCRIPTION
In a previous pull request ( #4 ) I added an `edit` route to for Organizations. I thought that the edit page (`/sfbrigade/organizations/<id>/edit`) would be where we'd implement [this organization edit UI](https://docs.google.com/file/d/0BxD7i_sk0-nqLU0tZldrOEZkcVU/edit).

After talking with Michael and Deborah, it turns out that the page in the mockup should be at the `show` route (`/sfbrigade/organizations/<id>`) for organizations, and that forms should be rendered inline.

This PR removes the `edit` route. A following PR will start to add inline forms into the `show` route.