### PR TITLE
Add a hound.yml file for Hound style checking

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,8 @@
+scss:
+  enabled: true
+coffee_script:
+  enabled: true
+java_script:
+  enabled: true
+ruby:
+  enabled: true


### PR DESCRIPTION
As we switch developers, it's important to keep a consistent style
throughout the code base. Hound can keep us from arguing over trivial
style problems in code reviews while letting us focus more on the actual
application code.

See:
houndci.com
http://robots.thoughtbot.com/introducing-hound