### PR TITLE
Fix deprecation warning when defining custom input

### DIFF
--- a/app/inputs/array_input.rb
+++ b/app/inputs/array_input.rb
@@ -4,7 +4,7 @@ class ArrayInput < SimpleForm::Inputs::StringInput
 
   TEXT_FIELD_CLASSES = "text optional array-element"
 
-  def input
+  def input(_wrapper_options)
     input_html_options[:type] ||= input_type
 
     content_tag(:div, class: "array-input") do


### PR DESCRIPTION
Since https://github.com/plataformatec/simple_form/pull/997,
custom input adapters must accept a hash of wrapper options