### PR TITLE
Fix data upload process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 ruby "2.1.5"
 
+gem "protected_attributes"
+
 gem "aasm"
 gem "active_model_serializers", "~> 0.8.0"
 gem "ancestry"
@@ -24,7 +26,6 @@ gem "passenger"
 gem "pg"
 gem "pg_search"
 gem "platform-api"
-gem "protected_attributes"
 gem "rack-cors", require: "rack/cors"
 gem "rack-timeout"
 gem "rails", "~> 4.1.1"

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,1 @@
+Delayed::Worker.delay_jobs = !Rails.env.test?

--- a/spec/factories/import_jobs.rb
+++ b/spec/factories/import_jobs.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :import_job do
+    url "http://example.com"
+  end
+end

--- a/spec/features/sfadmin/upload_data_spec.rb
+++ b/spec/features/sfadmin/upload_data_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+feature "Uploading data" do
+  scenario "uploading a JSON file" do
+    data_url = "https://raw.githubusercontent.com/sfbrigade/sf-openreferral/master/ss4women/1_100.json"
+
+    login_admin
+    visit "/"
+    click_on "New Import Job"
+    fill_in "Source Data URL", with: data_url
+    click_on "Create Import job"
+
+    expect(page).to have_content("30th Street Senior Center")
+    expect(page).to have_content("finished_job")
+  end
+end

--- a/spec/models/import_job_spec.rb
+++ b/spec/models/import_job_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe ImportJob do
+  describe "after_create" do
+    it "enqueues an import" do
+      import_job = FactoryGirl.build(:import_job)
+      allow(import_job).to receive(:perform)
+
+      import_job.save
+
+      expect(import_job).to have_received(:perform)
+    end
+  end
+end


### PR DESCRIPTION
Was broken in [26962682], when we sorted the Gemfile alphabetically.
Due to a conflict with the `protected_attributes` gem,
`protected_attributes` must appear before `delayed_job` in the Gemfile.

See https://github.com/collectiveidea/delayed_job#rails-4

[26962682]: https://github.com/sfbrigade/ohana-api/commit/26962682eaa627865383443b326805fad8acf17c