### PR TITLE
Simplify admin & user sign in spec helpers

### DIFF
--- a/spec/features/admin/sign_in_spec.rb
+++ b/spec/features/admin/sign_in_spec.rb
@@ -48,7 +48,7 @@ feature "Signing in" do
   scenario "with invalid credentials" do
     sign_in_admin("hello@example.com", "wrongpassword")
 
-    expect(page).to have_content "Invalid email or password"
+    expect(page).to have_content t("devise.failure.invalid")
   end
 
   scenario "with an unconfirmed admin" do
@@ -58,5 +58,14 @@ feature "Signing in" do
 
     expect(page).
       to have_content(t("devise.failure.unconfirmed"))
+  end
+
+  def sign_in_admin(email, password)
+    visit "/admin/sign_in"
+    within("#new_admin") do
+      fill_in "admin_email", with: email
+      fill_in "admin_password", with: password
+    end
+    click_button "Sign in"
   end
 end

--- a/spec/features/admin/sign_up_spec.rb
+++ b/spec/features/admin/sign_up_spec.rb
@@ -1,34 +1,43 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Signing up' do
-  scenario 'with all required fields present and valid' do
-    sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
-    expect(page).to have_content 'activate your account'
+feature "Signing up" do
+  scenario "with all required fields present and valid" do
+    sign_up_admin("Moncef", "moncef@foo.com", "ohanatest", "ohanatest")
+    expect(page).to have_content "activate your account"
     expect(current_path).to eq(new_admin_confirmation_path)
   end
 
-  scenario 'with name missing' do
-    sign_up_admin('', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+  scenario "with name missing" do
+    sign_up_admin("", "moncef@foo.com", "ohanatest", "ohanatest")
     expect(page).to have_content "Name can't be blank"
   end
 
-  scenario 'with email missing' do
-    sign_up_admin('Moncef', '', 'ohanatest', 'ohanatest')
+  scenario "with email missing" do
+    sign_up_admin("Moncef", "", "ohanatest", "ohanatest")
     expect(page).to have_content "Email can't be blank"
   end
 
-  scenario 'with password missing' do
-    sign_up_admin('Moncef', 'moncef@foo.com', '', 'ohanatest')
+  scenario "with password missing" do
+    sign_up_admin("Moncef", "moncef@foo.com", "", "ohanatest")
     expect(page).to have_content "Password can't be blank"
   end
 
-  scenario 'with password confirmation missing' do
-    sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', '')
+  scenario "with password confirmation missing" do
+    sign_up_admin("Moncef", "moncef@foo.com", "ohanatest", "")
     expect(page).to have_content "Password confirmation doesn't match Password"
   end
 
   scenario "when password and confirmation don't match" do
-    sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', 'ohana')
+    sign_up_admin("Moncef", "moncef@foo.com", "ohanatest", "ohana")
     expect(page).to have_content "Password confirmation doesn't match Password"
+  end
+
+  def sign_up_admin(name, email, password, confirmation)
+    visit "/admin/sign_up"
+    fill_in "admin_name", with: name
+    fill_in "admin_email", with: email
+    fill_in "admin_password", with: password
+    fill_in "admin_password_confirmation", with: confirmation
+    click_button "Sign up"
   end
 end

--- a/spec/features/sfadmin/edit_location_spec.rb
+++ b/spec/features/sfadmin/edit_location_spec.rb
@@ -4,7 +4,8 @@ feature "Editing a location" do
   scenario "accessing the form through navigation" do
     location = create(:location)
 
-    sign_in_as_admin
+    login_admin
+    visit "/"
     click_on "Browse"
     click_on location.organization.name
     click_on location.name
@@ -15,7 +16,8 @@ feature "Editing a location" do
   scenario "changing the location's name" do
     location = create(:location)
 
-    sign_in_as_admin
+    login_admin
+    visit "/"
     visit location_page(location)
     fill_in("Name", with: "Foobar")
     click_on "Update Location"
@@ -26,23 +28,13 @@ feature "Editing a location" do
   scenario "checking accessibility boxes" do
     location = create(:location, accessibility: [])
 
-    sign_in_as_admin
+    login_admin
+    visit "/"
     visit location_page(location)
     check "location_accessibility_disabled_parking"
     click_on "Update Location"
 
     expect(find("#location_accessibility_disabled_parking")).to be_checked
-  end
-
-  def sign_in_as_admin
-    admin = create(:admin)
-
-    visit "/"
-
-    fill_in "Email", with: admin.email
-    fill_in "Password", with: admin.password
-
-    click_on "Sign in"
   end
 
   def location_page(location)

--- a/spec/features/signin_spec.rb
+++ b/spec/features/signin_spec.rb
@@ -1,23 +1,32 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Signing in' do
-  # The 'sign_in' method is defined in spec/support/features/session_helpers.rb
-  context 'with correct credentials' do
+feature "Signing in" do
+  context "with correct credentials" do
     before :each do
       valid_user = FactoryGirl.create(:user)
       sign_in(valid_user.email, valid_user.password)
     end
   end
 
-  scenario 'with invalid credentials' do
-    sign_in('hello@example.com', 'wrongpassword')
-    expect(page).to have_content 'Invalid email or password'
+  scenario "with invalid credentials" do
+    sign_in("hello@example.com", "wrongpassword")
+    expect(page).to have_content t("devise.failure.invalid")
   end
 
-  scenario 'with an unconfirmed user' do
+  scenario "with an unconfirmed user" do
     unconfirmed_user = FactoryGirl.create(:unconfirmed_user)
     sign_in(unconfirmed_user.email, unconfirmed_user.password)
-    expect(page)
-      .to have_content 'You have to confirm your account before continuing.'
+    expect(page).to have_content t("devise.failure.unconfirmed")
+  end
+
+  def sign_in(email, password)
+    visit "/users/sign_in"
+
+    within("#new_user") do
+      fill_in "Email", with: email
+      fill_in "Password", with: password
+    end
+
+    click_button "Sign in"
   end
 end

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -1,28 +1,37 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Signing up' do
-  scenario 'with name missing' do
-    sign_up('', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+feature "Signing up" do
+  scenario "with name missing" do
+    sign_up("", "moncef@foo.com", "ohanatest", "ohanatest")
     expect(page).to have_content "Name can't be blank"
   end
 
-  scenario 'with email missing' do
-    sign_up('Moncef', '', 'ohanatest', 'ohanatest')
+  scenario "with email missing" do
+    sign_up("Moncef", "", "ohanatest", "ohanatest")
     expect(page).to have_content "Email can't be blank"
   end
 
-  scenario 'with password missing' do
-    sign_up('Moncef', 'moncef@foo.com', '', 'ohanatest')
+  scenario "with password missing" do
+    sign_up("Moncef", "moncef@foo.com", "", "ohanatest")
     expect(page).to have_content "Password can't be blank"
   end
 
-  scenario 'with password confirmation missing' do
-    sign_up('Moncef', 'moncef@foo.com', 'ohanatest', '')
+  scenario "with password confirmation missing" do
+    sign_up("Moncef", "moncef@foo.com", "ohanatest", "")
     expect(page).to have_content "Password confirmation doesn't match Password"
   end
 
   scenario "when password and confirmation don't match" do
-    sign_up('Moncef', 'moncef@foo.com', 'ohanatest', 'ohana')
+    sign_up("Moncef", "moncef@foo.com", "ohanatest", "ohana")
     expect(page).to have_content "Password confirmation doesn't match Password"
+  end
+
+  def sign_up(name, email, password, confirmation)
+    visit "/users/sign_up"
+    fill_in "user_name", with: name
+    fill_in "user_email", with: email
+    fill_in "user_password", with: password
+    fill_in "user_password_confirmation", with: confirmation
+    click_button "Sign up"
   end
 end

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -21,42 +21,6 @@ module Features
       login_as(user, scope: :user)
     end
 
-    def sign_in(email, password)
-      visit '/users/sign_in'
-      within('#new_user') do
-        fill_in 'Email',    with: email
-        fill_in 'Password', with: password
-      end
-      click_button 'Sign in'
-    end
-
-    def sign_in_admin(email, password)
-      visit '/admin/sign_in'
-      within('#new_admin') do
-        fill_in 'admin_email',    with: email
-        fill_in 'admin_password', with: password
-      end
-      click_button 'Sign in'
-    end
-
-    def sign_up(name, email, password, confirmation)
-      visit '/users/sign_up'
-      fill_in 'user_name',                  with: name
-      fill_in 'user_email',                 with: email
-      fill_in 'user_password',              with: password
-      fill_in 'user_password_confirmation', with: confirmation
-      click_button 'Sign up'
-    end
-
-    def sign_up_admin(name, email, password, confirmation)
-      visit '/admin/sign_up'
-      fill_in 'admin_name',                  with: name
-      fill_in 'admin_email',                 with: email
-      fill_in 'admin_password',              with: password
-      fill_in 'admin_password_confirmation', with: confirmation
-      click_button 'Sign up'
-    end
-
     def create_api_app(name, main_url, callback_url)
       click_link 'Register new application'
       within('#new_api_application') do


### PR DESCRIPTION
Many of them are only used in one file,
so move them to the file that they're used in.

Motivation: there was confusion between `sign_in_admin`,
which walked through the user interface to sign in an admin,
and `login_admin`, which used Devise & sessions to set the user
directly.