### PR TITLE
Don't create duplicate organizations on import

### DIFF
--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -29,89 +29,35 @@ class ImportJob < ActiveRecord::Base
   def perform
     start_job!
 
-    begin
-      data = open(url).read
-      records = JSON.parse(data)
-      records.each_with_index do |record, index|
-        begin
-          org, rejected = save_record(record)
-          logger.info(
-            { index: index, id: org.id, organization: rejected }.to_json
-          )
-        rescue
-          logger.info({ index: index, error: $!.to_s }.to_json)
-        end
-      end
-    rescue
-      puts $!.backtrace
-      puts $!
-    end
+    data = open(url).read
+    records = JSON.parse(data)
+    records.each { |record| save_organization(record) }
+
     finish_job!
   end
   handle_asynchronously :perform
 
-  def save_record(record)
-    Organization.transaction do
-      params = record.except('locations')
-      org = Organization.new params
-      # look for rejected params in Organization
-      sanitized = org.send :sanitize_for_mass_assignment, params
-      rejected = { rejected: [] }
-      params.each do |k, v|
-        rejected[:rejected] << k unless sanitized.has_key?(k)
-      end
-      if org.save(validate: false)
-        rejected[:locations] = []
-        locs = record['locations']
-        locs.each do |location|
-          params = location.merge(organization_id: org.id)
-          location = Location.new(params)
-          # look for rejected params in Location
-          sanitized = location.send :sanitize_for_mass_assignment, params
-          keys = []
-          params.each do |k, v|
-            keys << k unless sanitized.has_key?(k)
-          end
-          rejected[:locations] << { }
-          rejected[:locations].last[:rejected] = keys unless keys.empty?
-          [ :address, :contacts, :faxes, :mail_address, :phones, :services ].each do |klass|
-            key = "#{klass}_attributes"
-            if params[key]
-              if params[key].kind_of?(Hash)
-                obj = klass.to_s.singularize.classify.constantize.new
-                sanitized = obj.send :sanitize_for_mass_assignment, params[key]
-                keys = []
-                params[key].each do |k, v|
-                  keys << k unless sanitized.has_key?(k)
-                end
-                rejected[:locations].last[key] = { rejected: keys } unless keys.empty?
-              elsif params[key].kind_of?(Array)
-                obj = klass.to_s.singularize.classify.constantize.new
-                keys = []
-                params[key].each do |data|
-                  sanitized = obj.send :sanitize_for_mass_assignment, data
-                  data.each do |k, v|
-                    keys << k unless sanitized.has_key?(k) || keys.include?(k)
-                  end
-                end
-                rejected[:locations].last[key] = { rejected: keys } unless keys.empty?
-              end
-            end
-          end
-          location.save(validate: false)
-          rejected[:locations].last[:id] = location.id unless location.id.blank?
-          sleep 0.2 # to prevent Geocoder rate limit exception
-        end unless locs.nil?
-        organizations << org
-      end
-      return org, rejected
+  def save_organization(org_params)
+    organization = Organization.find_or_initialize_by(name: org_params["name"])
+    organization.update(org_params.except("locations"))
+    organization.save(validate: false)
+
+    locs = org_params["locations"] || []
+    locs.each { |location_params| save_location(location_params, organization) }
+
+    unless organizations.include? organization
+      organizations << organization
     end
   end
 
+  def save_location(location_params, organization)
+    Location.new(
+      location_params.merge(organization_id: organization.id)
+    ).save(validate: false)
+  end
+
   def cascade_delete
-    self.organizations.each do |org|
-      org.destroy
-    end
+    organizations.each(&:destroy)
   end
   handle_asynchronously :cascade_delete
 end

--- a/spec/models/import_job_spec.rb
+++ b/spec/models/import_job_spec.rb
@@ -36,14 +36,33 @@ describe ImportJob do
     it "imports locations for each organization" do
       url = "http://example.com/"
       languages = body[0][:locations][0][:languages]
-      stub_request(:get, url).
-        to_return(status: 200, body: body.to_json, headers: {})
+      stub_request(:get, url).to_return(status: 200, body: body.to_json)
 
       create(:import_job, url: url)
 
       imported_org = Organization.last
       expect(imported_org.name).to eq org_name
       expect(imported_org.locations.first.languages).to eq languages
+    end
+
+    it "does not create duplicate organizations (judged by name)" do
+      url = "http://example.com/"
+      stub_request(:get, url).to_return(status: 200, body: body.to_json)
+      create(:organization, name: org_name)
+
+      create(:import_job, url: url)
+
+      expect(Organization.count).to eq(1)
+    end
+
+    it "imports phone numbers for the organization" do
+      url = "http://example.com/"
+      stub_request(:get, url).to_return(status: 200, body: body.to_json)
+
+      create(:import_job, url: url)
+
+      imported_number = Organization.first.locations.first.phones.first.number
+      expect(imported_number).to eq("415 550-2210")
     end
   end
 


### PR DESCRIPTION
Organizations are judged to be duplicates if they share the same name

- Drastically clean up ImportJob code
- Get rid of blanket `rescue` statements

In this case, half-assed error handling is worse than no error handling.

I'd personally prefer to have the app fail noisily, so we can catch the
error in Honeybadger or the equivalent.

Related: set up Honeybadger (https://trello.com/c/AnQQ566X)